### PR TITLE
Export types, use `prepare` for typings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ notifications:
 node_js:
 - stable
 before_install:
-- npm install -g typings gulp && typings install
+- npm install -g typings gulp-cli
 script:
 - npm test

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "1.1.0",
   "description": "Simple errors",
   "main": "dist/lib/lib/incident.js",
+  "types": "dist/lib/lib/incident.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/demurgos/incident.git"
   },
   "scripts": {
+    "prepare": "typings install",
     "test": "gulp :lint && gulp lib-test:clean && gulp lib-test",
     "prepublishOnly": "npm test && gulp lib:dist"
   },


### PR DESCRIPTION
This commit adds two small fixes to `package.json`

It declares the entry point for type definitions in `package.json` and uses the `prepare` script to install typings.
