### PR TITLE
Version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Major: Remove the setter methods: `setName`, `setMessage`, `setCause`, `setData`.
   Use a simple assignation instead.
 - Major: A missing cause is now represented by `undefined` instead of `null`.
+- Minor: `Incident(error: Error)` can now convert to instances of the current
+  `Incident` constructor.
+- Minor: A simple function call allows to create errors that do not capture the stack
+- Internal: Define the public exports in a separate file (`src/lib/index.ts`)
 
 # 1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Next
 
-- Major: Use the Incident name as a discriminant for the data and cause.
+- Major: Use the Incident name as a discriminant property for the data and cause.
   This changes the signature from `Incident<Data>` to `Incident<Name, Data, Cause>`
 - Major: Remove the setter methods: `setName`, `setMessage`, `setCause`, `setData`.
   Use a simple assignation instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Next
+
+- Major: Use the Incident name as a discriminant for the data and cause.
+  This changes the signature from `Incident<Data>` to `Incident<Name, Data, Cause>`
+- Major: Remove the setter methods: `setName`, `setMessage`, `setCause`, `setData`.
+  Use a simple assignation instead.
+- Major: A missing cause is now represented by `undefined` instead of `null`.
+
 # 1.2.1
 
 - Patch: Fix library path in _package.json_

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npm install --save incident
 - Compatible with prototypal inheritance and ES6 classe inheritance
 - Distributed with type definitions for Typescript
 - Lazy stack capture and support for lazy message formatter: never called if not needed
+- No dependencies
 
 ```typescript
 // Example of type resolution on a discriminated type
@@ -58,10 +59,9 @@ function printError(error: BaseError): void {
 ### Exports
 
 ```typescript
-interface Interface; // Incident interface
-interface StaticInterface; // New-able and callable, returns instances implementing Interface
-interface Incident; // Alias for Interface
-function Incident; // Implements StaticInterface
+function Incident; // The Incident constructor
+interface StaticIncident; // Interface of the constructor
+interface Incident; // Interface of the instance
 ```
 
 ### `Incident`
@@ -187,6 +187,8 @@ Incident. You can use it normalize simple errors to Incident or mitigate module
 duplication if you rely on `instanceof`. The resulting incident will have the
 same name, message, stack and data. If the input error was an Incident with
 a lazy message or stack, it will remain non-evaluated.
+If the argument is already an instance of the current `Incident`, a copy will be
+created. If you added extra properties, they will be lost.
 
 |cause|name |data |message| Comment                                                         |
 |:---:|:---:|:---:|:-----:|:----------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -4,22 +4,7 @@
 [![Build status](https://img.shields.io/travis/demurgos/incident/master.svg?maxAge=2592000)](https://travis-ci.org/demurgos/incident)
 [![GitHub repository](https://img.shields.io/badge/Github-demurgos%2Fincident-blue.svg)](https://github.com/demurgos/incident)
 
-Simple errors
-
-## Features
-
-- Drop-in replacement for `Error`: __fully compatible with `Error`__ (both in Node and the browser)
-- Based on native `Error`s, support for `instanceof Error`
-- Easy name and data association for automated error handling
-- Track error causes (simple chain or multiple reasons)
-- Possibility to extends via standard JS inheritance to provide custom errors
-- built with TypeScript: type definition and ES6 builds available
-- Lazy stack-trace (so it does not slow down your app if you don't need it)
-- Lazy message formatter
-
-### Planned features
-
-- Better compatibility between `incident`'s defined in distinct modules (in case if this module is duplicated in the dependency tree)
+Simple powerful errors for Typescript and Javascript.
 
 ## Installation
 
@@ -27,48 +12,200 @@ Simple errors
 npm install --save incident
 ```
 
-## Usage ##
+## Features
+
+- Drop-in replacement for `Error`: __fully compatible with `Error`__ (both in Node and the browser)
+- Supports `instanceof Error` tests.
+- Built-in error causality tracking.
+- **Compatible with Typescript discriminated unions**. If you type the name, you can then use it
+  as a discriminant property to resolve the type of the data and cause.
+  See the example  below.
+- Compatible with prototypal inheritance and ES6 classe inheritance
+- Distributed with type definitions for Typescript
+- Lazy stack capture and support for lazy message formatter: never called if not needed
 
 ```typescript
-// ES6 import
+// Example of type resolution on a discriminated type
 import Incident from "incident";
 
-// ES5 import
-const Incident = require("incident").Incident;
+// Associate the name "SyntaxError" to {index: number}
+type SyntaxError = Incident<"SyntaxError", {index: number}, undefined>;
+// Associate the name "TypeError" to {typeName: string}
+type TypeError = Incident<"TypeError", {typeName: string}, undefined>;
+// Created a discriminated type
+type BaseError = SyntaxError | TypeError;
 
-let err: Incident;
-const cause: Error = new Error("Hi, I'm a cause");
-const name: string = "incident:demo-error";
-const data: any = {much: "information", such: "data", wow: "!"};
-const message: string = "Don't worry, it's just a demo error";
-const lazyMessage: (data: any) => string = (data: any) => {JSON.stringify(data)};
-
-err = new Incident();
-err = new Incident(message);
-err = new Incident(lazyMessage);
-err = new Incident(name, message);
-err = new Incident(name, lazyMessage);
-err = new Incident(name, data, message);
-err = new Incident(name, data, lazyMessage);
-err = new Incident(cause, message);
-err = new Incident(cause, lazyMessage);
-err = new Incident(cause, name, message);
-err = new Incident(cause, name, lazyMessage);
-err = new Incident(cause, name, data, message);
-err = new Incident(cause, name, data, lazyMessage);
-err = new Incident(data, message);
-err = new Incident(data, lazyMessage);
-```
-
-```typescript
-interface Incident<D extends {}> {
-  cause: Error;
-  name: string;
-  data: D;
-  message: string;
-  stack: string;
+// Example usage accepting the discriminated type
+function printError(error: BaseError): void {
+  // Switch on the discriminant
+  switch (error.name) {
+    case "SyntaxError":
+      // No need to cast: successfully resolved to SyntaxError
+      const index: number = error.data.index;
+      console.log(`Received a syntax error with index: ${index}`);
+      break;
+    case "TypeError":
+      // Successfully resolved to TypeError
+      const typename: string = error.data.typeName;
+      console.log(`Received a type error with typename: ${typename}`);
+      break;
+  }
 }
 ```
+
+## Usage
+
+### Exports
+
+```typescript
+interface Interface; // Incident interface
+interface StaticInterface; // New-able and callable, returns instances implementing Interface
+interface Incident; // Alias for Interface
+function Incident; // Implements StaticInterface
+```
+
+### `Incident`
+
+An `Incident` has the following interface:
+
+```typescript
+interface Incident<Name extends string, Data extends {}, Cause extends (Error | undefined)> extends Error {
+  name: Name;
+  message: string;
+  data: Data;
+  cause: Cause;
+  stack: string;
+  toString(): string;
+}
+```
+
+### Generic parameters
+
+- **Name**: The type of the name, use a literal string type to be able to switch
+  ont the name and benefit from Typescript's type discrimination.
+- **Data**: The interface of the data associated to this error. Must respect `typeof data === "object"`
+- **Cause**: The type of the error cause. Use `undefined` if there is no cause.
+
+### Attributes
+
+#### `name`
+
+A name uniquely identifying the error. Displayed at the top of the stack.
+
+#### `message`
+
+A debug message for developers describing the error. Displayed at the top of the stack.
+
+#### `data`
+
+A data object associated to the error. This should describe the error enough
+to handle it programmatically.
+
+#### `cause`
+
+A previous error that cause this error. This usually has more detail about
+what happened.
+
+#### `stack`
+
+The error stack of the incident. Contains the standard stack frames, and the
+stack of the cause if there is any.
+
+### Constructor
+
+```typescript
+new Incident<Name, Data, Cause>([cause,] [name,] [data,] [message]);
+```
+
+You can pass almost any combination of parameters you want as long as it is in the
+right order (see table below for the details). If you want to explicitly define the
+generic parameters, you don't have to define the generic parameter for a function parameter
+you do not use. Instanciating a new Incident instance will perform a lazy capture
+of the current call stack (only resolved when reading `.stack` or throwing the error).
+
+- **cause**
+  - Type: `Cause`
+  - Type constraint: If you provide a `cause`, `Cause extends Error` else `Cause` is `undefined`.
+  - Default type: `undefined`
+  - Default value: `undefined`
+  - Description: A previous error that caused this Incident.
+
+- **name**
+  - Type: `Name`
+  - Type constraint: `Name extends string`
+  - Default type: `"Incident"`
+  - Default value: `"Incident"`
+  - Description: A name allowing to discriminate the error data and cause.
+
+- **data**
+  - Type: `Data`
+  - Type constraint: `Data extends {}`
+  - Default type: `{}`
+  - Default value: `{}`
+  - Description: A data object completely describing the error.
+
+- **message**
+  - Type: `string | ((data?: typeof data) => string)`
+  - Default value: `""`
+  - Description: A debug message for developers. If the message is a formatter function,
+    it will be lazily evaluated (only once) when:
+    - the `message` property is accessed
+    - the `stack` property is accessed
+    - the error is thrown
+
+
+`new` operator signatures table
+
+|cause|name |data |message| Comment                                                             |
+|:---:|:---:|:---:|:-----:|:--------------------------------------------------------------------|
+|     |     |     |       |`new(): Incident<"Incident", {}, undefined>`                         |
+|     |     |     |   ✔   |`new(...): Incident<"Incident", {}, undefined>`                      |
+|     |     |  ✔  |       |`new<Data>(...): Incident<"Incident", Data, undefined>`              |
+|     |     |  ✔  |   ✔   |`new<Data>(...): Incident<"Incident", Data, undefined>`              |
+|     |  ✔  |     |       |**Not Planned**, use `new Incident(name, "")`                        |
+|     |  ✔  |     |   ✔   |`new<Name>(...): Incident<Name, {}, undefined>`                      |
+|     |  ✔  |  ✔  |       |**Planned**, use `new Incident(name, data, "")` until available      |
+|     |  ✔  |  ✔  |   ✔   |`new<Name, Data>(...): Incident<Name, Data, undefined>`              |
+|  ✔  |     |     |       |**Not Planned**, use `new Incident(cause, "")` or `Incident(cause)`  |
+|  ✔  |     |     |   ✔   |**Planned**, use `new Incident(cause, {}, "")` until available       |
+|  ✔  |     |  ✔  |       |`new<Data, Cause>(...): Incident<"Incident", Data, Cause>`           |
+|  ✔  |     |  ✔  |   ✔   |`new<Data, Cause>(...): Incident<"Incident", Data, Cause>`           |
+|  ✔  |  ✔  |     |       |`new<Name, Cause>(...): Incident<Name, {}, Cause>`                   |
+|  ✔  |  ✔  |     |   ✔   |`new<Name, Cause>(...): Incident<Name, {}, Cause>`                   |
+|  ✔  |  ✔  |  ✔  |       |**Planned**, use `new Incident(cause, name, data, "") until available|
+|  ✔  |  ✔  |  ✔  |   ✔   |`new<Name, Data, Cause>(...): Incident<Name, Data, Cause>`           |
+
+### Call
+
+You can call `Incident` as a simple function. It has the same signature as
+the `new` operator but **does not capture the stack**. You may want to use
+it for higher order errors, but I recommend to capture the stack for root causes.
+
+The simple call also supports the additional signature `(cause: Error)`.
+This will perform a conversion from any error to an instance of the currently called
+Incident. You can use it normalize simple errors to Incident or mitigate module
+duplication if you rely on `instanceof`. The resulting incident will have the
+same name, message, stack and data. If the input error was an Incident with
+a lazy message or stack, it will remain non-evaluated.
+
+|cause|name |data |message| Comment                                                         |
+|:---:|:---:|:---:|:-----:|:----------------------------------------------------------------|
+|     |     |     |       |`(): Incident<"Incident", {}, undefined>`                        |
+|     |     |     |   ✔   |`(...): Incident<"Incident", {}, undefined>`                     |
+|     |     |  ✔  |       |`<Data>(...): Incident<"Incident", Data, undefined>`             |
+|     |     |  ✔  |   ✔   |`<Data>(...): Incident<"Incident", Data, undefined>`             |
+|     |  ✔  |     |       |**Not Planned**, use `Incident(name, "")`                        |
+|     |  ✔  |     |   ✔   |`<Name>(...): Incident<Name, {}, undefined>`                     |
+|     |  ✔  |  ✔  |       |**Planned**, use `Incident(name, data, "")` until available      |
+|     |  ✔  |  ✔  |   ✔   |`<Name, Data>(...): Incident<Name, Data, undefined>`             |
+|  ✔  |     |     |       |Convert to an instance of this `Incident` constructor            |
+|  ✔  |     |     |   ✔   |**Planned**, use `new Incident(cause, {}, "")` until available   |
+|  ✔  |     |  ✔  |       |`<Data, Cause>(...): Incident<"Incident", Data, Cause>`          |
+|  ✔  |     |  ✔  |   ✔   |`<Data, Cause>(...): Incident<"Incident", Data, Cause>`          |
+|  ✔  |  ✔  |     |       |`<Name, Cause>(...): Incident<Name, {}, Cause>`                  |
+|  ✔  |  ✔  |     |   ✔   |`<Name, Cause>(...): Incident<Name, {}, Cause>`                  |
+|  ✔  |  ✔  |  ✔  |       |**Planned**, use `Incident(cause, name, data, "") until available|
+|  ✔  |  ✔  |  ✔  |   ✔   |`<Name, Data, Cause>(...): Incident<Name, Data, Cause>`          |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -156,24 +156,24 @@ of the current call stack (only resolved when reading `.stack` or throwing the e
 
 `new` operator signatures table
 
-|cause|name |data |message| Comment                                                             |
-|:---:|:---:|:---:|:-----:|:--------------------------------------------------------------------|
-|     |     |     |       |`new(): Incident<"Incident", {}, undefined>`                         |
-|     |     |     |   ✔   |`new(...): Incident<"Incident", {}, undefined>`                      |
-|     |     |  ✔  |       |`new<Data>(...): Incident<"Incident", Data, undefined>`              |
-|     |     |  ✔  |   ✔   |`new<Data>(...): Incident<"Incident", Data, undefined>`              |
-|     |  ✔  |     |       |**Not Planned**, use `new Incident(name, "")`                        |
-|     |  ✔  |     |   ✔   |`new<Name>(...): Incident<Name, {}, undefined>`                      |
-|     |  ✔  |  ✔  |       |**Planned**, use `new Incident(name, data, "")` until available      |
-|     |  ✔  |  ✔  |   ✔   |`new<Name, Data>(...): Incident<Name, Data, undefined>`              |
-|  ✔  |     |     |       |**Not Planned**, use `new Incident(cause, "")` or `Incident(cause)`  |
-|  ✔  |     |     |   ✔   |**Planned**, use `new Incident(cause, {}, "")` until available       |
-|  ✔  |     |  ✔  |       |`new<Data, Cause>(...): Incident<"Incident", Data, Cause>`           |
-|  ✔  |     |  ✔  |   ✔   |`new<Data, Cause>(...): Incident<"Incident", Data, Cause>`           |
-|  ✔  |  ✔  |     |       |`new<Name, Cause>(...): Incident<Name, {}, Cause>`                   |
-|  ✔  |  ✔  |     |   ✔   |`new<Name, Cause>(...): Incident<Name, {}, Cause>`                   |
-|  ✔  |  ✔  |  ✔  |       |**Planned**, use `new Incident(cause, name, data, "") until available|
-|  ✔  |  ✔  |  ✔  |   ✔   |`new<Name, Data, Cause>(...): Incident<Name, Data, Cause>`           |
+|cause|name |data |message| Comment                                                            |
+|:---:|:---:|:---:|:-----:|:-------------------------------------------------------------------|
+|     |     |     |       |`new(): Incident<"Incident", {}, undefined>`                        |
+|     |     |     |   ✔   |`new(...): Incident<"Incident", {}, undefined>`                     |
+|     |     |  ✔  |       |`new<Data>(...): Incident<"Incident", Data, undefined>`             |
+|     |     |  ✔  |   ✔   |`new<Data>(...): Incident<"Incident", Data, undefined>`             |
+|     |  ✘  |     |       |**Not possible**, use `new Incident(name, "")`                      |
+|     |  ✔  |     |   ✔   |`new<Name>(...): Incident<Name, {}, undefined>`                     |
+|     |  ✔  |  ✔  |       |`new<Name, Data>(...): Incident<Name, Data, undefined>`             |
+|     |  ✔  |  ✔  |   ✔   |`new<Name, Data>(...): Incident<Name, Data, undefined>`             |
+|  ✘  |     |     |       |**Not possible**, use `new Incident(cause, "")` or `Incident(cause)`|
+|  ✔  |     |     |   ✔   |`new<Cause>(...): Incident<"Incident", {}, Cause>`                  |
+|  ✔  |     |  ✔  |       |`new<Data, Cause>(...): Incident<"Incident", Data, Cause>`          |
+|  ✔  |     |  ✔  |   ✔   |`new<Data, Cause>(...): Incident<"Incident", Data, Cause>`          |
+|  ✘  |  ✘  |     |       |**Not possible**, use `new Incident(cause, name, "")`               |
+|  ✔  |  ✔  |     |   ✔   |`new<Name, Cause>(...): Incident<Name, {}, Cause>`                  |
+|  ✔  |  ✔  |  ✔  |       |`new<Name, Data, Cause>(...): Incident<Name, Data, Cause>`          |
+|  ✔  |  ✔  |  ✔  |   ✔   |`new<Name, Data, Cause>(...): Incident<Name, Data, Cause>`          |
 
 ### Call
 
@@ -190,24 +190,24 @@ a lazy message or stack, it will remain non-evaluated.
 If the argument is already an instance of the current `Incident`, a copy will be
 created. If you added extra properties, they will be lost.
 
-|cause|name |data |message| Comment                                                         |
-|:---:|:---:|:---:|:-----:|:----------------------------------------------------------------|
-|     |     |     |       |`(): Incident<"Incident", {}, undefined>`                        |
-|     |     |     |   ✔   |`(...): Incident<"Incident", {}, undefined>`                     |
-|     |     |  ✔  |       |`<Data>(...): Incident<"Incident", Data, undefined>`             |
-|     |     |  ✔  |   ✔   |`<Data>(...): Incident<"Incident", Data, undefined>`             |
-|     |  ✔  |     |       |**Not Planned**, use `Incident(name, "")`                        |
-|     |  ✔  |     |   ✔   |`<Name>(...): Incident<Name, {}, undefined>`                     |
-|     |  ✔  |  ✔  |       |**Planned**, use `Incident(name, data, "")` until available      |
-|     |  ✔  |  ✔  |   ✔   |`<Name, Data>(...): Incident<Name, Data, undefined>`             |
-|  ✔  |     |     |       |Convert to an instance of this `Incident` constructor            |
-|  ✔  |     |     |   ✔   |**Planned**, use `new Incident(cause, {}, "")` until available   |
-|  ✔  |     |  ✔  |       |`<Data, Cause>(...): Incident<"Incident", Data, Cause>`          |
-|  ✔  |     |  ✔  |   ✔   |`<Data, Cause>(...): Incident<"Incident", Data, Cause>`          |
-|  ✔  |  ✔  |     |       |`<Name, Cause>(...): Incident<Name, {}, Cause>`                  |
-|  ✔  |  ✔  |     |   ✔   |`<Name, Cause>(...): Incident<Name, {}, Cause>`                  |
-|  ✔  |  ✔  |  ✔  |       |**Planned**, use `Incident(cause, name, data, "") until available|
-|  ✔  |  ✔  |  ✔  |   ✔   |`<Name, Data, Cause>(...): Incident<Name, Data, Cause>`          |
+|cause|name |data |message| Comment                                                 |
+|:---:|:---:|:---:|:-----:|:--------------------------------------------------------|
+|     |     |     |       |`(): Incident<"Incident", {}, undefined>`                |
+|     |     |     |   ✔   |`(...): Incident<"Incident", {}, undefined>`             |
+|     |     |  ✔  |       |`<Data>(...): Incident<"Incident", Data, undefined>`     |
+|     |     |  ✔  |   ✔   |`<Data>(...): Incident<"Incident", Data, undefined>`     |
+|     |  ✘  |     |       |**Not possible**, use `Incident(name, "")`               |
+|     |  ✔  |     |   ✔   |`<Name>(...): Incident<Name, {}, undefined>`             |
+|     |  ✔  |  ✔  |       |`new<Name, Data>(...): Incident<Name, Data, undefined>`  |
+|     |  ✔  |  ✔  |   ✔   |`<Name, Data>(...): Incident<Name, Data, undefined>`     |
+|  ✔  |     |     |       |**Convert to an instance of this `Incident` constructor**|
+|  ✔  |     |     |   ✔   |`<Cause>(...): Incident<"Incident", {}, Cause>`          |
+|  ✔  |     |  ✔  |       |`<Data, Cause>(...): Incident<"Incident", Data, Cause>`  |
+|  ✔  |     |  ✔  |   ✔   |`<Data, Cause>(...): Incident<"Incident", Data, Cause>`  |
+|  ✘  |  ✘  |     |       |**Not possible**, use `Incident(cause, name, "")`        |
+|  ✔  |  ✔  |     |   ✔   |`<Name, Cause>(...): Incident<Name, {}, Cause>`          |
+|  ✔  |  ✔  |  ✔  |       |`<Name, Data, Cause>(...): Incident<Name, Data, Cause>`  |
+|  ✔  |  ✔  |  ✔  |   ✔   |`<Name, Data, Cause>(...): Incident<Name, Data, Cause>`  |
 
 ## License
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,7 @@ const libTarget = Object.assign(
       compilerOptions: {
         skipLibCheck: true,
         target: "es2015",
-        lib: ["es2015", "dom"]
+        lib: ["es2015"]
       },
       typescript: typescript,
       tsconfigJson: ["lib/tsconfig.json"]
@@ -59,7 +59,8 @@ const libTestTarget = Object.assign(
     typescript: {
       compilerOptions: {
         skipLibCheck: true,
-        target: "es2015"
+        target: "es2015",
+        lib: ["es2015"]
       },
       typescript: typescript,
       tsconfigJson: ["test/tsconfig.json"]

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "incident",
   "version": "1.2.1",
   "description": "Simple powerful errors",
-  "main": "dist/lib-es2015/lib/incident.js",
-  "types": "dist/lib-es2015/lib/incident.d.ts",
-  "browser": "dist/lib-es5/lib/incident.js",
+  "main": "dist/lib-es2015/lib/index.js",
+  "types": "dist/lib-es2015/lib/index.d.ts",
+  "browser": "dist/lib-es5/lib/index.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/demurgos/incident.git"
@@ -34,6 +34,6 @@
     "demurgos-web-build-tools": "0.13.0-beta.5",
     "gulp": "github:gulpjs/gulp#4.0",
     "pre-commit": "^1.2.2",
-    "typescript": "^2.3.0-dev.20170420"
+    "typescript": "^2.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "demurgos-web-build-tools": "0.13.0-beta.5",
     "gulp": "github:gulpjs/gulp#4.0",
     "pre-commit": "^1.2.2",
-    "typescript": "^2.1.4"
+    "typescript": "^2.3.0-dev.20170420"
   }
 }

--- a/src/lib/incident.ts
+++ b/src/lib/incident.ts
@@ -187,11 +187,11 @@ function createIncident(_super: Function): StaticInterface {
         const stack: string = this._stack === null ?
           this._stackContainer.stack :
           this._stackContainer.stack.replace(/^[^\n]+\n[^\n]+\n/, "");
-        this._stack = this._message === "" ?
+        this._stack = this.message === "" ?
           `${this.name}\n${stack}` :
-          `${this.name}: ${this._message}\n${stack}`;
+          `${this.name}: ${this.message}\n${stack}`;
       } else {
-        this._stack = this._message === "" ? this.name : `${this.name}: ${this._message}`;
+        this._stack = this.message === "" ? this.name : `${this.name}: ${this.message}`;
       }
       if (this.cause !== undefined && this.cause.stack !== undefined) {
         this._stack = `${this._stack}\n  caused by ${this.cause.stack}`;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,2 @@
+export {Incident} from "./incident";
+export {StaticIncident} from "./interfaces";

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -18,7 +18,8 @@ export interface Incident<Name extends string, Data extends {}, Cause extends (E
 export interface StaticIncident extends Function {
 //new<                                C extends Error>(cause: C                                                              ): Incident<"Incident", {}, C        >;
   new<                                C extends Error>(cause: C,                   message : string | ((data?: {}) => string)): Incident<"Incident", {}, C        >;
-  new<N extends string,               C extends Error>(cause: C, name: N,          message?: string | ((data?: {}) => string)): Incident<N         , {}, C        >;
+//new<N extends string,               C extends Error>(cause: C, name: N,                                                    ): Incident<N         , {}, C        >;
+  new<N extends string,               C extends Error>(cause: C, name: N,          message : string | ((data?: {}) => string)): Incident<N         , {}, C        >;
   new                                                 (                            message?: string | ((data?: {}) => string)): Incident<"Incident", {}, undefined>;
 //new<N extends string                               >(          name: N,                                                    ): Incident<N,          {}, undefined>;
   new<N extends string                               >(          name: N,          message : string | ((data?: {}) => string)): Incident<N,          {}, undefined>;
@@ -29,7 +30,8 @@ export interface StaticIncident extends Function {
 
      <                                C extends Error>(cause: C                                                              ): Incident<"Incident", {}, C        >;
      <                                C extends Error>(cause: C,                   message : string | ((data?: {}) => string)): Incident<"Incident", {}, C        >;
-     <N extends string,               C extends Error>(cause: C, name: N,          message?: string | ((data?: {}) => string)): Incident<N         , {}, C        >;
+//   <N extends string,               C extends Error>(cause: C, name: N,                                                    ): Incident<N         , {}, C        >;
+     <N extends string,               C extends Error>(cause: C, name: N,          message : string | ((data?: {}) => string)): Incident<N         , {}, C        >;
                                                       (                            message?: string | ((data?: {}) => string)): Incident<"Incident", {}, undefined>;
 //   <N extends string                               >(          name: N,                                                    ): Incident<N,          {}, undefined>;
      <N extends string                               >(          name: N,          message : string | ((data?: {}) => string)): Incident<N,          {}, undefined>;

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -1,0 +1,40 @@
+export interface Attributes<Name extends string, Data extends {}, Cause extends (Error | undefined)> {
+  message: string;
+  name: Name;
+  data: Data;
+  cause: Cause;
+  stack: string;
+}
+
+export interface Incident<Name extends string, Data extends {}, Cause extends (Error | undefined)>
+  extends Error, Attributes<Name, Data, Cause> {
+  name: Name;
+  stack: string;
+
+  toString(): string;
+}
+
+/* tslint:disable:comment-format max-line-length typedef-whitespace */
+export interface StaticIncident extends Function {
+//new<                                C extends Error>(cause: C                                                              ): Incident<"Incident", {}, C        >;
+  new<                                C extends Error>(cause: C,                   message : string | ((data?: {}) => string)): Incident<"Incident", {}, C        >;
+  new<N extends string,               C extends Error>(cause: C, name: N,          message?: string | ((data?: {}) => string)): Incident<N         , {}, C        >;
+  new                                                 (                            message?: string | ((data?: {}) => string)): Incident<"Incident", {}, undefined>;
+//new<N extends string                               >(          name: N,                                                    ): Incident<N,          {}, undefined>;
+  new<N extends string                               >(          name: N,          message : string | ((data?: {}) => string)): Incident<N,          {}, undefined>;
+  new<N extends string, D extends {}, C extends Error>(cause: C, name: N, data: D, message?: string | ((data?: D) => string) ): Incident<N         , D,  C        >;
+  new<                  D extends {}, C extends Error>(cause: C,          data: D, message?: string | ((data?: D) => string) ): Incident<"Incident", D,  C        >;
+  new<N extends string, D extends {}                 >(          name: N, data: D, message?: string | ((data?: {}) => string)): Incident<N,          D,  undefined>;
+  new<                  D extends {}                 >(                   data: D, message?: string | ((data?: D ) => string)): Incident<"Incident", D,  undefined>;
+
+     <                                C extends Error>(cause: C                                                              ): Incident<"Incident", {}, C        >;
+     <                                C extends Error>(cause: C,                   message : string | ((data?: {}) => string)): Incident<"Incident", {}, C        >;
+     <N extends string,               C extends Error>(cause: C, name: N,          message?: string | ((data?: {}) => string)): Incident<N         , {}, C        >;
+                                                      (                            message?: string | ((data?: {}) => string)): Incident<"Incident", {}, undefined>;
+//   <N extends string                               >(          name: N,                                                    ): Incident<N,          {}, undefined>;
+     <N extends string                               >(          name: N,          message : string | ((data?: {}) => string)): Incident<N,          {}, undefined>;
+     <N extends string, D extends {}, C extends Error>(cause: C, name: N, data: D, message?: string | ((data?: D) => string) ): Incident<N         , D,  C        >;
+     <                  D extends {}, C extends Error>(cause: C,          data: D, message?: string | ((data?: D) => string) ): Incident<"Incident", D,  C        >;
+     <N extends string, D extends {}                 >(          name: N, data: D, message?: string | ((data?: {}) => string)): Incident<N,          D,  undefined>;
+     <                  D extends {}                 >(                   data: D, message?: string | ((data?: D ) => string)): Incident<"Incident", D,  undefined>;
+}

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -18,24 +18,26 @@ export interface Incident<Name extends string, Data extends {}, Cause extends (E
 export interface StaticIncident extends Function {
 //new<                                C extends Error>(cause: C                                                              ): Incident<"Incident", {}, C        >;
   new<                                C extends Error>(cause: C,                   message : string | ((data?: {}) => string)): Incident<"Incident", {}, C        >;
-//new<N extends string,               C extends Error>(cause: C, name: N,                                                    ): Incident<N         , {}, C        >;
-  new<N extends string,               C extends Error>(cause: C, name: N,          message : string | ((data?: {}) => string)): Incident<N         , {}, C        >;
+//new<N extends string,               C extends Error>(cause: C, name: N,                                                    ): Incident<N,          {}, C        >;
+  new<N extends string,               C extends Error>(cause: C, name: N,          message : string | ((data?: {}) => string)): Incident<N,          {}, C        >;
   new                                                 (                            message?: string | ((data?: {}) => string)): Incident<"Incident", {}, undefined>;
 //new<N extends string                               >(          name: N,                                                    ): Incident<N,          {}, undefined>;
   new<N extends string                               >(          name: N,          message : string | ((data?: {}) => string)): Incident<N,          {}, undefined>;
-  new<N extends string, D extends {}, C extends Error>(cause: C, name: N, data: D, message?: string | ((data?: D) => string) ): Incident<N         , D,  C        >;
+  new<N extends string, D extends {}, C extends Error>(cause: C, name: N, data: D, message?: string | ((data?: D) => string) ): Incident<N,          D,  C        >;
   new<                  D extends {}, C extends Error>(cause: C,          data: D, message?: string | ((data?: D) => string) ): Incident<"Incident", D,  C        >;
   new<N extends string, D extends {}                 >(          name: N, data: D, message?: string | ((data?: {}) => string)): Incident<N,          D,  undefined>;
   new<                  D extends {}                 >(                   data: D, message?: string | ((data?: D ) => string)): Incident<"Incident", D,  undefined>;
 
-     <                                C extends Error>(cause: C                                                              ): Incident<"Incident", {}, C        >;
+     <N extends string, D extends {}, C extends Error | undefined>(error: Error & {name: N, data?: D, cause?: C}             ): Incident<N,          D,  C        >;
+                                                                  (error: Error                                              ): Incident<string,     {}, undefined>;
+
      <                                C extends Error>(cause: C,                   message : string | ((data?: {}) => string)): Incident<"Incident", {}, C        >;
-//   <N extends string,               C extends Error>(cause: C, name: N,                                                    ): Incident<N         , {}, C        >;
-     <N extends string,               C extends Error>(cause: C, name: N,          message : string | ((data?: {}) => string)): Incident<N         , {}, C        >;
+//   <N extends string,               C extends Error>(cause: C, name: N,                                                    ): Incident<N,          {}, C        >;
+     <N extends string,               C extends Error>(cause: C, name: N,          message : string | ((data?: {}) => string)): Incident<N,          {}, C        >;
                                                       (                            message?: string | ((data?: {}) => string)): Incident<"Incident", {}, undefined>;
 //   <N extends string                               >(          name: N,                                                    ): Incident<N,          {}, undefined>;
      <N extends string                               >(          name: N,          message : string | ((data?: {}) => string)): Incident<N,          {}, undefined>;
-     <N extends string, D extends {}, C extends Error>(cause: C, name: N, data: D, message?: string | ((data?: D) => string) ): Incident<N         , D,  C        >;
+     <N extends string, D extends {}, C extends Error>(cause: C, name: N, data: D, message?: string | ((data?: D) => string) ): Incident<N,          D,  C        >;
      <                  D extends {}, C extends Error>(cause: C,          data: D, message?: string | ((data?: D) => string) ): Incident<"Incident", D,  C        >;
      <N extends string, D extends {}                 >(          name: N, data: D, message?: string | ((data?: {}) => string)): Incident<N,          D,  undefined>;
      <                  D extends {}                 >(                   data: D, message?: string | ((data?: D ) => string)): Incident<"Incident", D,  undefined>;

--- a/src/test/incident.spec.ts
+++ b/src/test/incident.spec.ts
@@ -334,12 +334,8 @@ describe("Discriminated union", function () {
 
   it("should compile a discriminated Incident", function () {
     {
-      interface SyntaxError extends Incident<"SyntaxError", {index: number}, undefined> {
-      }
-
-      interface TypeError extends Incident<"TypeError", {typeName: string}, undefined> {
-      }
-
+      type SyntaxError = Incident<"SyntaxError", {index: number}, undefined>;
+      type TypeError = Incident<"TypeError", {typeName: string}, undefined>;
       type BaseError = SyntaxError | TypeError;
 
       function printError(error: BaseError): void {

--- a/src/test/incident.spec.ts
+++ b/src/test/incident.spec.ts
@@ -31,7 +31,7 @@ describe("Incident", function () {
   });
 });
 
-describe("Incident constructors", function () {
+describe("new Incident(...)", function () {
   it("new Incident(cause,             message  )", function () {
     type Cause = Incident<"QuantumEffect", {}, undefined>;
     const cause: Cause = new Incident("QuantumEffect", "What is even a cause?");
@@ -325,8 +325,335 @@ describe("Incident constructors", function () {
   });
 });
 
+// TODO(Demurgos): Come up with some original errors to keep reading the tests interesting
+describe("Incident(...)", function () {
+  it("Incident(cause,             message  )", function () {
+    type Cause = Incident<"QuantumEffect", {}, undefined>;
+    const cause: Cause = Incident("QuantumEffect", "What is even a cause?");
+    const incident: Incident<"Incident", {}, Cause> = Incident(cause, "Quantum stuff is rad but weird");
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "Incident",
+      data: {},
+      message: "Quantum stuff is rad but weird"
+    });
+  });
+
+  it("Incident(cause,             formatter)", function () {
+    // These stunts are performed by trained professionals, don't try this at home
+    type Cause = Incident<"NotANumber", {value: number}, undefined>;
+    const numberBox: {value: number} = {value: NaN};
+    const cause: Cause = Incident("NotANumber", numberBox, "The number box contains NaN");
+    const incident: Incident<"Incident", {}, Cause> = Incident(
+      cause,
+      () => `Error with the number box containing ${numberBox.value}`
+    );
+    // Seriously, if you use a formatter with a lazy message, avoid to rely on mutable data reference you don't control
+    numberBox.value = 0;
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "Incident",
+      data: {},
+      message: "Error with the number box containing 0"
+    });
+  });
+
+  it("Incident(cause, name,       message  )", function () {
+    type Cause = Incident<"Hardware", {}, undefined>;
+    const cause: Cause = Incident("Hardware", "This is a hardware issue");
+    const incident: Incident<"LightBulb", {}, Cause> = Incident(cause, "LightBulb", "Unable to change light bulb");
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "LightBulb",
+      data: {},
+      message: "Unable to change light bulb"
+    });
+  });
+
+  it("Incident(cause, name,       formatter)", function () {
+    type Cause = Incident<"CauseNotFound", {}, undefined>;
+    const cause: Cause = Incident("CauseNotFound", "Unable to find a cause to test with");
+    const incident: Incident<"CauseFound", {}, Cause> = Incident(
+      cause,
+      "CauseFound",
+      () => "Found a cause"
+    );
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "CauseFound",
+      data: {},
+      message: "Found a cause"
+    });
+  });
+
+  it("Incident(                            )", function () {
+    const incident: Incident<"Incident", {}, undefined> = Incident();
+    assertEqualErrors(incident, {
+      name: Incident.name,
+      data: {},
+      message: ""
+    });
+  });
+
+  it("Incident(                   message  )", function () {
+    const incident: Incident<"Incident", {}, undefined> = Incident("Unable to fire the reactor!");
+    assertEqualErrors(incident, {
+      name: Incident.name,
+      data: {},
+      message: "Unable to fire the reactor!"
+    });
+  });
+
+  it("Incident(                   formatter)", function () {
+    const incident: Incident<"Incident", {}, undefined> = Incident(() => "The reactor is on fire!");
+    assertEqualErrors(incident, {
+      name: Incident.name,
+      data: {},
+      message: "The reactor is on fire!"
+    });
+  });
+
+  it("Incident(       name,       message  )", function () {
+    const incident: Incident<"paradoxError", {}, undefined> = Incident("paradoxError", "This is not an error");
+    assertEqualErrors(incident, {
+      name: "paradoxError",
+      data: {},
+      message: "This is not an error"
+    });
+  });
+
+  it("Incident(       name,       formatter)", function () {
+    type ParadoxError = Incident<"paradoxError", {}, undefined>;
+    const incident: ParadoxError = Incident("paradoxError", () => "This is not an error");
+    assertEqualErrors(incident, {
+      name: "paradoxError",
+      data: {},
+      message: "This is not an error"
+    });
+  });
+
+  it("Incident(cause, name, data,          )", function () {
+    type Cause = Incident<"WrapMe", {}, undefined>;
+    const cause: Cause = Incident("WrapMe", "This error justs draws attention to itself");
+    const incident: Incident<"SimpleWrapper", {simple: true}, Cause> = Incident(
+      cause,
+      "SimpleWrapper",
+      {simple: true as true}
+    );
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "SimpleWrapper",
+      data: {simple: true},
+      message: ""
+    });
+  });
+
+  it("Incident(cause, name, data, message  )", function () {
+    // Trivia: `example.com` is a special domain reserved by the IANA, anyone can use it for illustrative purposes
+    type Cause = Incident<"ConnectionLost", {}, undefined>;
+    const cause: Cause = Incident("ConnectionLost", "Lost connection");
+    const incident: Incident<"Network", {uri: string}, Cause> = Incident(
+      cause,
+      "Network",
+      {uri: "example.com"},
+      "Unable to connect"
+    );
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "Network",
+      data: {uri: "example.com"},
+      message: "Unable to connect"
+    });
+  });
+
+  it("Incident(cause, name, data, formatter)", function () {
+    type Cause = Incident<"MinLength", {minLength: number}, undefined>;
+    const cause: Cause = Incident("MinLength", {minLength: 59}, "Value must have `.length` ≥ 59");
+    const incident: Incident<"InvalidCityName", {value: string}, Cause> = Incident(
+      cause,
+      "InvalidCityName",
+      {value: "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch"},
+      (data: {value: string}): string => `The value ${JSON.stringify(data.value)} is an invalid city name`
+    );
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "InvalidCityName",
+      data: {value: "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch"},
+      message: `The value "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch" is an invalid city name`
+    });
+  });
+
+  it("Incident(cause,       data,          )", function () {
+    type Cause = Incident<"NeedForEasyErrorManagement", {}, undefined>;
+    const cause: Cause = Incident("NeedForEasyErrorManagement", "");
+    const now: Date = new Date();
+    const incident: Incident<"Incident", {homepage: string, author: string}, Cause> = Incident(
+      cause,
+      {homepage: "https://github.com/demurgos/incident", author: "Demurgos"}
+    );
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "Incident",
+      data: {homepage: "https://github.com/demurgos/incident", author: "Demurgos"},
+      message: ""
+    });
+  });
+
+  it("Incident(cause,       data, message  )", function () {
+    type Cause = Incident<"Http", {status: number}, undefined>;
+    const cause: Cause = Incident("Http", {status: 200}, "200 - OK");
+    const now: Date = new Date();
+    const incident: Incident<"Incident", {time: Date}, Cause> = Incident(
+      cause,
+      {time: now},
+      "Surprise error"
+    );
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "Incident",
+      data: {time: now},
+      message: "Surprise error"
+    });
+  });
+
+  it("Incident(cause,       data, message  )", function () {
+    type Cause = Incident<"Http", {status: number}, undefined>;
+    const cause: Cause = Incident("Http", {status: 200}, "200 - OK");
+    const now: Date = new Date();
+    const incident: Incident<"Incident", {time: Date}, Cause> = Incident(
+      cause,
+      {time: now},
+      "Surprise error"
+    );
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "Incident",
+      data: {time: now},
+      message: "Surprise error"
+    });
+  });
+
+  it("Incident(cause,       data, formatter)", function () {
+    enum Unit {Kelvin, Celsius, Farenheit}
+    type Cause = Incident<"Temperature", {temperature: number, unit: Unit}, undefined>;
+    // Sorry if you use imperial units
+    const cause: Cause = Incident("Temperature", {temperature: -273.15, unit: Unit.Celsius}, "It's 0K");
+    const incident: Incident<"Incident", {endOfTheWorld: boolean}, Cause> = Incident(
+      cause,
+      {endOfTheWorld: true},
+      (data: {endOfTheWorld: boolean}) => data.endOfTheWorld ? "Seems pretty serious" : "Could be worse"
+    );
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "Incident",
+      data: {endOfTheWorld: true},
+      message: "Seems pretty serious"
+    });
+  });
+
+  it("Incident(       name, data           )", function () {
+    const incident: Incident<"AintNobodyGotTimeForMessages", {timeForMessages: number}, undefined> = Incident(
+      "AintNobodyGotTimeForMessages",
+      {timeForMessages: 0}
+    );
+    assertEqualErrors(incident, {
+      name: "AintNobodyGotTimeForMessages",
+      data: {timeForMessages: 0},
+      message: ""
+    });
+  });
+
+  it("Incident(       name, data, message  )", function () {
+    const htmlRegExp: RegExp = /<html>/;
+    const incident: Incident<"RegExp", {regExp: RegExp}, undefined> = Incident(
+      "RegExp",
+      {regExp: htmlRegExp},
+      "Now you have two errors"
+    );
+    assertEqualErrors(incident, {
+      name: "RegExp",
+      data: {regExp: htmlRegExp},
+      message: "Now you have two errors"
+    });
+  });
+
+  it("Incident(       name, data, formatter)", function () {
+    const antiRegExp: RegExp = /[^]/;
+    const incident: Incident<"RegExp", {regex: RegExp}, undefined> = Incident(
+      "RegExp",
+      {regex: antiRegExp},
+      (data: {regex: RegExp}) => `The RegExp for ${JSON.stringify(data.regex.source)} does not want to cooperate`
+    );
+    assertEqualErrors(incident, {
+      name: "RegExp",
+      data: {regex: antiRegExp},
+      message: `The RegExp for "[^]" does not want to cooperate`
+    });
+  });
+
+  it("Incident(             data           )", function () {
+    const incident: Incident<"Incident", {port: number}, undefined> = Incident({port: 50313});
+    assertEqualErrors(incident, {
+      name: Incident.name,
+      data: {port: 50313},
+      message: ""
+    });
+  });
+
+  it("Incident(             data, message  )", function () {
+    // You know you're getting tired of coming up with errors when you resort to foo & bar...
+    const incident: Incident<"Incident", {foo: string}, undefined> = Incident({foo: "bar"}, "Foo/Bar");
+    assertEqualErrors(incident, {
+      name: Incident.name,
+      data: {foo: "bar"},
+      message: "Foo/Bar"
+    });
+  });
+
+  it("Incident(             data, formatter)", function () {
+    const incident: Incident<"Incident", {bar: string}, undefined> = Incident({bar: "foo"}, () => "Bar/Foo");
+    assertEqualErrors(incident, {
+      name: Incident.name,
+      data: {bar: "foo"},
+      message: "Bar/Foo"
+    });
+  });
+});
+
+describe("Incident(error)", function () {
+  it("Incident(error: Error)", function () {
+    const base: Error = new Error("Simple error");
+    const incident: Incident<string, {}, undefined> = Incident(base);
+    assertEqualErrors(incident, {
+      name: "Error",
+      data: {},
+      message: "Simple error"
+    });
+    assert.instanceOf(incident, Incident);
+  });
+
+  it("Incident(error: Incident<N, D, C>)", function () {
+    const cause: Error = new Error("Please move along, this is just a dummy cause");
+    const base: Incident<"UdpJoke", {rating: number}, Error> = Incident(
+      cause,
+      "UdpJoke",
+      {rating: Infinity},
+      "I'd tell you a UDP joke, but you might not get it."
+    );
+    const incident: Incident<"UdpJoke", {rating: number}, Error> = Incident(base);
+    assertEqualErrors(incident, {
+      name: "UdpJoke",
+      data: {rating: Infinity},
+      message: "I'd tell you a UDP joke, but you might not get it.",
+      cause: cause
+    });
+    assert.instanceOf(incident, Incident);
+    assert.notEqual(incident, base);
+  });
+});
+
 describe("Lazy message", function () {
-  it("should call the formatter lazily on first read", function () {
+  it("should call the formatter lazily on the first message read", function () {
     const callOrder: string[] = [];
 
     function exec() {
@@ -341,6 +668,38 @@ describe("Lazy message", function () {
       callOrder.push("after-read");
       callOrder.push("before-read2");
       assert.isString(incident.message);
+      callOrder.push("after-read2");
+      callOrder.push("end-of-exec");
+    }
+
+    exec();
+    assert.deepEqual(callOrder, [
+      "start-of-exec",
+      "created-incident",
+      "before-read",
+      "message-evaluation",
+      "after-read",
+      "before-read2",
+      "after-read2",
+      "end-of-exec"
+    ]);
+  });
+
+  it("should call the formatter lazily on the first stack read", function () {
+    const callOrder: string[] = [];
+
+    function exec() {
+      callOrder.push("start-of-exec");
+      const incident: Incident<"Incident", {}, undefined> = new Incident((): string => {
+        callOrder.push("message-evaluation");
+        return "Lazy error";
+      });
+      callOrder.push("created-incident");
+      callOrder.push("before-read");
+      assert.isString(incident.stack);
+      callOrder.push("after-read");
+      callOrder.push("before-read2");
+      assert.isString(incident.stack);
       callOrder.push("after-read2");
       callOrder.push("end-of-exec");
     }
@@ -390,6 +749,36 @@ describe("Lazy message", function () {
       "after-throw",
       "before-throw2",
       "after-throw2",
+      "end-of-exec"
+    ]);
+  });
+
+  it("Conversion from Incident to Incident should not evaluate the message eagerly", function () {
+    const callOrder: string[] = [];
+
+    function exec() {
+      callOrder.push("start-of-exec");
+      const base: Incident<"Incident", {}, undefined> = new Incident((): string => {
+        callOrder.push("message-evaluation");
+        return "Lazy error";
+      });
+      callOrder.push("created-base");
+      const copy: Incident<"Incident", {}, undefined> = Incident(base);
+      callOrder.push("after-copy");
+      callOrder.push("before-read");
+      assert.isString(copy.message);
+      callOrder.push("after-read");
+      callOrder.push("end-of-exec");
+    }
+
+    exec();
+    assert.deepEqual(callOrder, [
+      "start-of-exec",
+      "created-base",
+      "after-copy",
+      "before-read",
+      "message-evaluation",
+      "after-read",
       "end-of-exec"
     ]);
   });

--- a/src/test/incident.spec.ts
+++ b/src/test/incident.spec.ts
@@ -32,7 +32,66 @@ describe("Incident", function () {
 });
 
 describe("Incident constructors", function () {
-  it("new Incident()", function () {
+  it("new Incident(cause,             message  )", function () {
+    type Cause = Incident<"QuantumEffect", {}, undefined>;
+    const cause: Cause = new Incident("QuantumEffect", "What is even a cause?");
+    const incident: Incident<"Incident", {}, Cause> = new Incident(cause, "Quantum stuff is rad but weird");
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "Incident",
+      data: {},
+      message: "Quantum stuff is rad but weird"
+    });
+  });
+
+  it("new Incident(cause,             formatter)", function () {
+    // These stunts are performed by trained professionals, don't try this at home
+    type Cause = Incident<"NotANumber", {value: number}, undefined>;
+    const numberBox: {value: number} = {value: NaN};
+    const cause: Cause = new Incident("NotANumber", numberBox, "The number box contains NaN");
+    const incident: Incident<"Incident", {}, Cause> = new Incident(
+      cause,
+      () => `Error with the number box containing ${numberBox.value}`
+    );
+    // Seriously, if you use a formatter with a lazy message, avoid to rely on mutable data reference you don't control
+    numberBox.value = 0;
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "Incident",
+      data: {},
+      message: "Error with the number box containing 0"
+    });
+  });
+
+  it("new Incident(cause, name,       message  )", function () {
+    type Cause = Incident<"Hardware", {}, undefined>;
+    const cause: Cause = new Incident("Hardware", "This is a hardware issue");
+    const incident: Incident<"LightBulb", {}, Cause> = new Incident(cause, "LightBulb", "Unable to change light bulb");
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "LightBulb",
+      data: {},
+      message: "Unable to change light bulb"
+    });
+  });
+
+  it("new Incident(cause, name,       formatter)", function () {
+    type Cause = Incident<"CauseNotFound", {}, undefined>;
+    const cause: Cause = new Incident("CauseNotFound", "Unable to find a cause to test with");
+    const incident: Incident<"CauseFound", {}, Cause> = new Incident(
+      cause,
+      "CauseFound",
+      () => "Found a cause"
+    );
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "CauseFound",
+      data: {},
+      message: "Found a cause"
+    });
+  });
+
+  it("new Incident(                            )", function () {
     const incident: Incident<"Incident", {}, undefined> = new Incident();
     assertEqualErrors(incident, {
       name: Incident.name,
@@ -41,7 +100,7 @@ describe("Incident constructors", function () {
     });
   });
 
-  it("new Incident(message)", function () {
+  it("new Incident(                   message  )", function () {
     const incident: Incident<"Incident", {}, undefined> = new Incident("Unable to fire the reactor!");
     assertEqualErrors(incident, {
       name: Incident.name,
@@ -50,16 +109,16 @@ describe("Incident constructors", function () {
     });
   });
 
-  it("new Incident(lazyMessage)", function () {
-    const incident: Incident<"Incident", {}, undefined> = new Incident(() => "Unable to fire the reactor!");
+  it("new Incident(                   formatter)", function () {
+    const incident: Incident<"Incident", {}, undefined> = new Incident(() => "The reactor is on fire!");
     assertEqualErrors(incident, {
       name: Incident.name,
       data: {},
-      message: "Unable to fire the reactor!"
+      message: "The reactor is on fire!"
     });
   });
 
-  it("new Incident(name, message)", function () {
+  it("new Incident(       name,       message  )", function () {
     const incident: Incident<"paradoxError", {}, undefined> = new Incident("paradoxError", "This is not an error");
     assertEqualErrors(incident, {
       name: "paradoxError",
@@ -68,7 +127,7 @@ describe("Incident constructors", function () {
     });
   });
 
-  it("new Incident(name, lazyMessage)", function () {
+  it("new Incident(       name,       formatter)", function () {
     type ParadoxError = Incident<"paradoxError", {}, undefined>;
     const incident: ParadoxError = new Incident("paradoxError", () => "This is not an error");
     assertEqualErrors(incident, {
@@ -78,122 +137,176 @@ describe("Incident constructors", function () {
     });
   });
 
-  it("new Incident(name, data, message)", function () {
-    const htmlRegex: RegExp = /<html>/;
-    const incident: Incident<"regexError", {regex: RegExp}, undefined> = new Incident(
-      "regexError",
-      {regex: htmlRegex},
-      "Now you have two errors"
-    );
-    assertEqualErrors(incident, {
-      name: "regexError",
-      data: {regex: htmlRegex},
-      message: "Now you have two errors"
-    });
-  });
-
-  it("new Incident(name, data, lazyMessage)", function () {
-    const htmlRegex: RegExp = /<html>/;
-    const incident: Incident<"regexError", {regex: RegExp}, undefined> = new Incident(
-      "regexError",
-      {regex: htmlRegex},
-      () => "Now you have two errors"
-    );
-    assertEqualErrors(incident, {
-      name: "regexError",
-      data: {regex: htmlRegex},
-      message: "Now you have two errors"
-    });
-  });
-
-  it("new Incident(cause, message)", function () {
-    type Cause = Incident<"quantumError", {}, undefined>;
-    const cause: Cause = new Incident("quantumError", "Causality not found");
-    const incident: Incident<"Incident", {}, Cause> = new Incident(cause, "Unable to predict particle");
-    assertEqualErrors(incident, {
-      cause: cause,
-      name: "Incident", // do not inherit name of cause
-      data: {},
-      message: "Unable to predict particle"
-    });
-  });
-
-  it("new Incident(cause, lazyMessage)", function () {
-    type Cause = Incident<"quantumError", {}, undefined>;
-    const cause: Cause = new Incident("quantumError", "Causality not found");
-    const incident: Incident<"Incident", {}, Cause> = new Incident(cause, () => "Unable to predict particle");
-    assertEqualErrors(incident, {
-      cause: cause,
-      name: "Incident", // do not inherit name of cause
-      data: {},
-      message: "Unable to predict particle"
-    });
-  });
-
-  it("new Incident(cause, name, message)", function () {
-    type Cause = Incident<"hardwareError", {}, undefined>;
-    const cause: Cause = new Incident("hardwareError", "This is a hardware issue");
-    type LightBultError = Incident<"lightBulbError", {}, Cause>;
-    const incident: LightBultError = new Incident(cause, "lightBulbError", "Unable to change light bulb");
-    assertEqualErrors(incident, {
-      cause: cause,
-      name: "lightBulbError",
-      data: {},
-      message: "Unable to change light bulb"
-    });
-  });
-
-  it("new Incident(cause, name, lazyMessage)", function () {
-    type Cause = Incident<"hardwareError", {}, undefined>;
-    const cause: Cause = new Incident("hardwareError", "This is a hardware issue");
-    const incident: Incident<"lightBulbError", {}, Cause> = new Incident(
+  it("new Incident(cause, name, data,          )", function () {
+    type Cause = Incident<"WrapMe", {}, undefined>;
+    const cause: Cause = new Incident("WrapMe", "This error justs draws attention to itself");
+    const incident: Incident<"SimpleWrapper", {simple: true}, Cause> = new Incident(
       cause,
-      "lightBulbError",
-      () => "Unable to change light bulb"
+      "SimpleWrapper",
+      {simple: true as true}
     );
     assertEqualErrors(incident, {
       cause: cause,
-      name: "lightBulbError",
-      data: {},
-      message: "Unable to change light bulb"
+      name: "SimpleWrapper",
+      data: {simple: true},
+      message: ""
     });
   });
 
-  it("new Incident(cause, name, data, message)", function () {
-    type Cause = Incident<"lostConnectionError", {}, undefined>;
-    const cause: Cause = new Incident("lostConnectionError", "Lost connection");
-    const incident: Incident<"netError", {uri: string}, Cause> = new Incident(
+  it("new Incident(cause, name, data, message  )", function () {
+    // Trivia: `example.com` is a special domain reserved by the IANA, anyone can use it for illustrative purposes
+    type Cause = Incident<"ConnectionLost", {}, undefined>;
+    const cause: Cause = new Incident("ConnectionLost", "Lost connection");
+    const incident: Incident<"Network", {uri: string}, Cause> = new Incident(
       cause,
-      "netError",
+      "Network",
       {uri: "example.com"},
       "Unable to connect"
     );
     assertEqualErrors(incident, {
       cause: cause,
-      name: "netError",
+      name: "Network",
       data: {uri: "example.com"},
       message: "Unable to connect"
     });
   });
 
-  it("new Incident(cause, name, data, lazyMessage)", function () {
-    type Cause = Incident<"lostConnectionError", {}, undefined>;
-    const cause: Cause = new Incident("lostConnectionError", "Lost connection");
-    const incident: Incident<"netError", {uri: string}, Cause> = new Incident(
+  it("new Incident(cause, name, data, formatter)", function () {
+    type Cause = Incident<"MinLength", {minLength: number}, undefined>;
+    const cause: Cause = new Incident("MinLength", {minLength: 59}, "Value must have `.length` ≥ 59");
+    const incident: Incident<"InvalidCityName", {value: string}, Cause> = new Incident(
       cause,
-      "netError",
-      {uri: "example.com"},
-      () => "Unable to connect"
+      "InvalidCityName",
+      {value: "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch"},
+      (data: {value: string}): string => `The value ${JSON.stringify(data.value)} is an invalid city name`
     );
     assertEqualErrors(incident, {
       cause: cause,
-      name: "netError",
-      data: {uri: "example.com"},
-      message: "Unable to connect"
+      name: "InvalidCityName",
+      data: {value: "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch"},
+      message: `The value "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch" is an invalid city name`
     });
   });
 
-  it("new Incident(data, message)", function () {
+  it("new Incident(cause,       data,          )", function () {
+    type Cause = Incident<"NeedForEasyErrorManagement", {}, undefined>;
+    const cause: Cause = new Incident("NeedForEasyErrorManagement", "");
+    const now: Date = new Date();
+    const incident: Incident<"Incident", {homepage: string, author: string}, Cause> = new Incident(
+      cause,
+      {homepage: "https://github.com/demurgos/incident", author: "Demurgos"}
+    );
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "Incident",
+      data: {homepage: "https://github.com/demurgos/incident", author: "Demurgos"},
+      message: ""
+    });
+  });
+
+  it("new Incident(cause,       data, message  )", function () {
+    type Cause = Incident<"Http", {status: number}, undefined>;
+    const cause: Cause = new Incident("Http", {status: 200}, "200 - OK");
+    const now: Date = new Date();
+    const incident: Incident<"Incident", {time: Date}, Cause> = new Incident(
+      cause,
+      {time: now},
+      "Surprise error"
+    );
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "Incident",
+      data: {time: now},
+      message: "Surprise error"
+    });
+  });
+
+  it("new Incident(cause,       data, message  )", function () {
+    type Cause = Incident<"Http", {status: number}, undefined>;
+    const cause: Cause = new Incident("Http", {status: 200}, "200 - OK");
+    const now: Date = new Date();
+    const incident: Incident<"Incident", {time: Date}, Cause> = new Incident(
+      cause,
+      {time: now},
+      "Surprise error"
+    );
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "Incident",
+      data: {time: now},
+      message: "Surprise error"
+    });
+  });
+
+  it("new Incident(cause,       data, formatter)", function () {
+    enum Unit {Kelvin, Celsius, Farenheit}
+    type Cause = Incident<"Temperature", {temperature: number, unit: Unit}, undefined>;
+    // Sorry if you use imperial units
+    const cause: Cause = new Incident("Temperature", {temperature: -273.15, unit: Unit.Celsius}, "It's 0K");
+    const incident: Incident<"Incident", {endOfTheWorld: boolean}, Cause> = new Incident(
+      cause,
+      {endOfTheWorld: true},
+      (data: {endOfTheWorld: boolean}) => data.endOfTheWorld ? "Seems pretty serious" : "Could be worse"
+    );
+    assertEqualErrors(incident, {
+      cause: cause,
+      name: "Incident",
+      data: {endOfTheWorld: true},
+      message: "Seems pretty serious"
+    });
+  });
+
+  it("new Incident(       name, data           )", function () {
+    const incident: Incident<"AintNobodyGotTimeForMessages", {timeForMessages: number}, undefined> = new Incident(
+      "AintNobodyGotTimeForMessages",
+      {timeForMessages: 0}
+    );
+    assertEqualErrors(incident, {
+      name: "AintNobodyGotTimeForMessages",
+      data: {timeForMessages: 0},
+      message: ""
+    });
+  });
+
+  it("new Incident(       name, data, message  )", function () {
+    const htmlRegExp: RegExp = /<html>/;
+    const incident: Incident<"RegExp", {regExp: RegExp}, undefined> = new Incident(
+      "RegExp",
+      {regExp: htmlRegExp},
+      "Now you have two errors"
+    );
+    assertEqualErrors(incident, {
+      name: "RegExp",
+      data: {regExp: htmlRegExp},
+      message: "Now you have two errors"
+    });
+  });
+
+  it("new Incident(       name, data, formatter)", function () {
+    const antiRegExp: RegExp = /[^]/;
+    const incident: Incident<"RegExp", {regex: RegExp}, undefined> = new Incident(
+      "RegExp",
+      {regex: antiRegExp},
+      (data: {regex: RegExp}) => `The RegExp for ${JSON.stringify(data.regex.source)} does not want to cooperate`
+    );
+    assertEqualErrors(incident, {
+      name: "RegExp",
+      data: {regex: antiRegExp},
+      message: `The RegExp for "[^]" does not want to cooperate`
+    });
+  });
+
+  it("new Incident(             data           )", function () {
+    const incident: Incident<"Incident", {port: number}, undefined> = new Incident({port: 50313});
+    assertEqualErrors(incident, {
+      name: Incident.name,
+      data: {port: 50313},
+      message: ""
+    });
+  });
+
+  it("new Incident(             data, message  )", function () {
+    // You know you're getting tired of coming up with errors when you resort to foo & bar...
     const incident: Incident<"Incident", {foo: string}, undefined> = new Incident({foo: "bar"}, "Foo/Bar");
     assertEqualErrors(incident, {
       name: Incident.name,
@@ -202,12 +315,12 @@ describe("Incident constructors", function () {
     });
   });
 
-  it("new Incident(data, lazyMessage)", function () {
-    const incident: Incident<"Incident", {foo: string}, undefined> = new Incident({foo: "bar"}, () => "Foo/Bar");
+  it("new Incident(             data, formatter)", function () {
+    const incident: Incident<"Incident", {bar: string}, undefined> = new Incident({bar: "foo"}, () => "Bar/Foo");
     assertEqualErrors(incident, {
       name: Incident.name,
-      data: {foo: "bar"},
-      message: "Foo/Bar"
+      data: {bar: "foo"},
+      message: "Bar/Foo"
     });
   });
 });

--- a/src/test/incident.spec.ts
+++ b/src/test/incident.spec.ts
@@ -1,5 +1,3 @@
-/* tslint:disable:no-angle-bracket-type-assertion */
-
 import {assert} from "chai";
 import {Incident} from "../lib/incident";
 
@@ -16,7 +14,13 @@ function assertEqualErrors<N extends string, D extends {}, C extends (Error | un
   expected: IncidentLike<N, D, C>
 ): void | never {
   for (const key in expected) {
-    assert.deepEqual((<any> actual)[key], (<any> expected)[key], `for attribute ${key}`);
+    const actualProperty: any = (<any> actual)[key];
+    const expectedProperty: any = (<any> expected)[key];
+    assert.deepEqual(
+      actualProperty,
+      expectedProperty,
+      `Expected \`${actualProperty}\` to be \`${expectedProperty}\` for ${key}`
+    );
   }
 }
 


### PR DESCRIPTION
This MR adds the main features of the version 2 of `Incident`:
- `name` as a discriminant property for the data and cause
- Conversions and stack-less errors or wrappers
- `undefined` instead of `null` for missing causes
