### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 2.0.0
 
 - Major: Use the Incident name as a discriminant property for the data and cause.
   This changes the signature from `Incident<Data>` to `Incident<Name, Data, Cause>`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "incident",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Simple powerful errors",
   "main": "dist/lib-es2015/lib/index.js",
   "types": "dist/lib-es2015/lib/index.d.ts",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,2 +1,4 @@
-export {Incident} from "./incident";
+import {Incident} from "./incident";
+export {Incident}
 export {StaticIncident} from "./interfaces";
+export  default Incident;


### PR DESCRIPTION
Changelog:

- Major: Use the Incident name as a discriminant property for the data and cause.
  This changes the signature from `Incident<Data>` to `Incident<Name, Data, Cause>`
- Major: Remove the setter methods: `setName`, `setMessage`, `setCause`, `setData`.
  Use a simple assignation instead.
- Major: A missing cause is now represented by `undefined` instead of `null`.
- Minor: `Incident(error: Error)` can now convert to instances of the current
  `Incident` constructor.
- Minor: A simple function call allows to create errors that do not capture the stack
- Internal: Define the public exports in a separate file (`src/lib/index.ts`)